### PR TITLE
Add tutorials of TF on FL

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Please find below all the contributed resources, organised by category
     * [Federated CPU Tracker Member (part1)](https://syftbox-documentation.openmined.org/cpu-tracker-1) - An example of SyftBox API that monitors local CPU usage and shares a private/sanitized version of the data within the SyftBox federated network.
     * [Federated CPU Tracker Leader (part 2)](https://syftbox-documentation.openmined.org/cpu-tracker-2) - A SyftBox API that aggregates CPU data from all members contributing to the computation, and creates a live visualization dashboard.
 
-* [From Centralised to Decentralised Training: An Intro to Federated Learning](https://github.com/deep-learning-indaba/indaba-pracs-2024/tree/main/practicals/Federated_Learning) - A Jupyter Notebook tutorial aimed to provide a practical overview with code examples to all the the foundational concepts tackled in federated learning. This tutorial was written by Andrej Jovanović, Sree Harsha Nelaturu and Luca Powell and presented at the 2024 iteration of the Deep Learning Indaba. 
+* [From Centralised to Decentralised Training: An Intro to Federated Learning](https://github.com/deep-learning-indaba/indaba-pracs-2024/tree/main/practicals/Federated_Learning) - A Jupyter Notebook tutorial aimed to provide a practical overview with code examples to all the the foundational concepts tackled in federated learning. This tutorial was written by Andrej Jovanović, Sree Harsha Nelaturu and Luca Powell and presented at the 2024 iteration of the Deep Learning Indaba.
+  
+* [Collection of Tutorials in Federate Learning from Tensor Flow](https://www.tensorflow.org/federated/tutorials/tutorials_overview) - A TensorFlow Colab Notebook collection of Federated Learning tutorials designed to provide practical examples of Federated Learning, covering concepts from basic to advanced levels.
 
 ### Articles
 


### PR DESCRIPTION
Adding list of Tensor Flow tutorials on the federate leaning. This tutorial contains basic to advance use case of federate leanirng on colab.

## Resource Addition

### Category
Tutorials

### Description
This tutorial is from TF on different use cases of Federate learning with colab to eailsy understand and go step by step.

### Checklist
 * [x]  I have followed the contribution guidelines
 * [x] The resource is freely accessible (or marked if paid)
 * [x]  I have added it to the appropriate category
 * [x]  The link is functional
 * [x]  The description is clear and concise