### PR TITLE
OpenVector CoFHE Github Repo not found 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Please find below all the contributed resources, organised by category
 
 - [SyftBox](https://github.com/OpenMined/syft) - Discover SyftBox, an exciting new project by OpenMined that puts Privacy-Enhancing Technologies at its core.
 
-- [OpenVector](https://openvector.gitbook.io/openvector) - CoFHE (Collaborative-Fully Homomorphic Encryption). Confidential compute primitive that is 100x faster than FHE. [Github repo not found for this tool]
+- [OpenVector](https://openvector.gitbook.io/openvector) - CoFHE (Collaborative-Fully Homomorphic Encryption). Confidential compute primitive that is 100x faster than FHE. **[Github repo not found for this tool]**
 
 - [PanzaMail](https://github.com/IST-DASLab/PanzaMail) - Panza is an automated email assistant customized to your writing style and past email history, trained without ever sharing your sensitive data.
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Please find below all the contributed resources, organised by category
 
 - [SyftBox](https://github.com/OpenMined/syft) - Discover SyftBox, an exciting new project by OpenMined that puts Privacy-Enhancing Technologies at its core.
 
-- [OpenVector](https://openvector.gitbook.io/openvector) - CoFHE (Collaborative-Fully Homomorphic Encryption). Confidential compute primitive that is 100x faster than FHE.
+- [OpenVector](https://openvector.gitbook.io/openvector) - CoFHE (Collaborative-Fully Homomorphic Encryption). Confidential compute primitive that is 100x faster than FHE. [Github repo not found for this tool]
 
 - [PanzaMail](https://github.com/IST-DASLab/PanzaMail) - Panza is an automated email assistant customized to your writing style and past email history, trained without ever sharing your sensitive data.
 


### PR DESCRIPTION
## Resource Addition
[OpenVector](https://openvector.gitbook.io/openvector) - CoFHE does not have a public repo for the code mentioned in the docs, so people should know about it before diving deeper.

### Category
Tools

### Description
Does not have a public repo for the code mentioned in the docs, so people should know about it before diving deeper.

<img width="1585" alt="image" src="https://github.com/user-attachments/assets/e32c0615-2650-4b83-a97a-abbeb3f1fd61">


### Checklist
- [x] I have followed the contribution guidelines
- [x] The resource is freely accessible (or marked if paid)
- [x] I have added it to the appropriate category
- [x] The link is functional
- [x] The description is clear and concise