### PR TITLE
Add pfl tutorials by Apple Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Please find below all the contributed resources, organised by category
 - [SubstraFL Tutorials by Owkin](https://docs.substra.org/en/stable/examples/substrafl/index.html) - These tutorials are for getting started with SubstraFL, which is a open-source Federated Learning Framework developed by Owkin Research focused on Healthcare.
 - [FedML Tutorials by TensorOpera (Previously FEDML)](https://docs.tensoropera.ai/federate/getting_started) - Getting started tutorials on Federated Learning for FedML by TensorOpera. FedML is a library for large-scale distributed training, model serving, and federated learning.
 - [FedLab Tutorials](https://fedlab.readthedocs.io/en/master/tutorials/tutorial.html) - Tutorials for FedLab (A flexible Federated Learning Framework based on PyTorch) by [SMILELab-FL](https://github.com/SMILELab-FL). FedLab aims to standardize FL simulation procedure, including synchronous algorithm, asynchronous algorithm and communication compression.
+- [PFL Tutorials by Apple](https://github.com/apple/pfl-research/tree/develop/tutorials) - A collection of tutorial notebooks for [pfl](https://apple.github.io/pfl-research/) which is a simulation framework for accelerating research in Private Federated Learning by Apple Research.
 
 ### Articles
 


### PR DESCRIPTION
## Resource Addition
Added link to `pfl` tutorial notebooks by Apple Research. 

`pfl-research` GitHub: https://github.com/apple/pfl-research 

### Category
<!-- Which category does this resource belong to? -->

### Description
<!-- Brief description of what you're adding -->

### Checklist
- [x] I have followed the contribution guidelines
- [x] The resource is freely accessible (or marked if paid)
- [x] I have added it to the appropriate category
- [x] The link is functional
- [x] The description is clear and concise